### PR TITLE
Configure Cloudflare Workers deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ docker compose up
 ```bash
 npx drizzle-kit push:sqlite
 ```
+
+## Cloudflare Workers へのデプロイ
+
+Cloudflare Workers にデプロイするには次の手順を実行します:
+
+```bash
+pnpm add -D @sveltejs/adapter-cloudflare wrangler
+pnpm run build
+pnpm run deploy
+```
+
+`wrangler.toml` の `[vars]` セクションに環境変数を設定してください。

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"deploy": "wrangler deploy",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check .",
@@ -13,6 +14,7 @@
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.0.0",
+		"@sveltejs/adapter-cloudflare": "^4.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@types/better-sqlite3": "^7.6.11",
@@ -23,7 +25,8 @@
 		"svelte": "^4.2.7",
 		"svelte-check": "^4.0.0",
 		"typescript": "^5.0.0",
-		"vite": "^5.0.3"
+		"vite": "^5.0.3",
+		"wrangler": "^3.0.0"
 	},
 	"type": "module",
 	"dependencies": {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from "@sveltejs/adapter-auto";
+import adapter from "@sveltejs/adapter-cloudflare";
 import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -8,9 +8,7 @@ const config = {
 	preprocess: vitePreprocess(),
 
 	kit: {
-		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
+		// Cloudflare Workers にデプロイするためのアダプター
 		adapter: adapter()
 	}
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,10 @@
+name = "sveltekit-prisma-google-oidc-demo"
+main = "./.svelte-kit/cloudflare/worker.js"
+compatibility_date = "2024-05-01"
+
+[vars]
+GOOGLE_CLIENT_ID = ""
+GOOGLE_CLIENT_SECRET = ""
+DATABASE_URL = ""
+REDIS_HOSTNAME = ""
+REDIS_PORT = ""


### PR DESCRIPTION
## Summary
- switch SvelteKit to Cloudflare adapter
- add `wrangler.toml` and deployment script for Workers
- document Cloudflare Workers deployment steps

## Testing
- `pnpm run lint`
- `pnpm run check` *(fails: Cannot find package '@sveltejs/adapter-cloudflare')*

------
https://chatgpt.com/codex/tasks/task_e_68b5ab43a2fc832b8ca233c70ade043d